### PR TITLE
Release gsdesign-python 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## gsdesign-python 0.1.0
+
+- Increment version number to 0.1.0 to follow semantic versioning
+  best practices (#6).
+
 ## gsdesign-python 0.0.1
 
 ### New features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gsdesign"
-version = "0.0.1"
+version = "0.1.0"
 description = "Group sequential design"
 authors = [
     { name = "Nan Xiao", email = "me@nanx.me" }

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "gsdesign"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
This PR bumps the version number to 0.1.0 and updates the changelog.